### PR TITLE
fix: adds a default config to resolve focus issue for Portals apps

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/IonicPortals.iml" filepath="$PROJECT_DIR$/.idea/modules/IonicPortals.iml" />
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/IonicPortals/IonicPortals.IonicPortals.iml" filepath="$PROJECT_DIR$/.idea/modules/IonicPortals/IonicPortals.IonicPortals.iml" />
-    </modules>
-  </component>
-</project>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.5.1](https://github.com/ionic-team/ionic-portals/compare/0.4.2...0.5.1) (2022-05-4)
+
+* **android:**  adds a default config to resolve focus issue for Portals apps in Android ([#2](https://github.com/ionic-team/ionic-portals-android/pull/2))
+
+
+
+
+
+
 # [0.5.0](https://github.com/ionic-team/ionic-portals/compare/0.4.2...0.5.0) (2022-02-16)
 
 **Note:** Version bump only for package ionic-portals-android

--- a/IonicPortals/build.gradle.kts
+++ b/IonicPortals/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("maven-publish")
     id("com.android.library")
-    kotlin("plugin.serialization") version "1.5.31"
+    kotlin("plugin.serialization")
     kotlin("android")
 }
 

--- a/IonicPortals/build.gradle.kts
+++ b/IonicPortals/build.gradle.kts
@@ -38,7 +38,7 @@ android {
 dependencies {
     implementation(kotlin("reflect"))
 
-    api("com.capacitorjs:core:3.4.1")
+    api("com.capacitorjs:core:3.5.1")
     compileOnly("io.ionic:liveupdates:0.0.5")
 
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.0")

--- a/IonicPortals/src/main/kotlin/io/ionic/portals/PortalFragment.kt
+++ b/IonicPortals/src/main/kotlin/io/ionic/portals/PortalFragment.kt
@@ -135,6 +135,11 @@ open class PortalFragment : Fragment {
                 if (portal != null) {
                     val startDir: String = portal?.startDir!!
                     initialPlugins.addAll(portal?.plugins!!)
+
+                    if(config == null) {
+                        config = CapConfig.Builder(requireContext()).setInitialFocus(false).create()
+                    }
+
                     bridge = Bridge.Builder(this)
                         .setInstanceState(savedInstanceState)
                         .setPlugins(initialPlugins)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,8 +19,8 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
         mavenCentral()
+        jcenter()
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ionic-portals-android",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Ionic Portals",
   "homepage": "https://ionic.io/portals",
   "author": "Ionic Team <hi@ionic.io> (https://ionic.io)",


### PR DESCRIPTION
Works in conjunction with https://github.com/ionic-team/capacitor/pull/5579 to have webviews in Portals apps load without taking focus by default. Configurable by adding a config programmatically to any Portal and setting value to `true`.