### PR TITLE
fix: fixed race condition when loading fragment with initialContext

### DIFF
--- a/IonicPortals/build.gradle.kts
+++ b/IonicPortals/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
     implementation(kotlin("reflect"))
 
     api("com.capacitorjs:core:3.5.1")
-    compileOnly("io.ionic:liveupdates:0.0.5")
+    compileOnly("io.ionic:liveupdates:0.0.7")
 
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.0")
     implementation( "androidx.core:core-ktx:1.6.0")


### PR DESCRIPTION
Setting the initial context on the DOM on page load ran async with the page load and it was possible for the page to load and for the javascript to check for initial context before it got set. Moving it here ensures it always runs before the page loads.