### PR TITLE
fix: added webview destroy call to PortalFragment

### DIFF
--- a/IonicPortals/src/main/kotlin/io/ionic/portals/PortalFragment.kt
+++ b/IonicPortals/src/main/kotlin/io/ionic/portals/PortalFragment.kt
@@ -55,6 +55,7 @@ open class PortalFragment : Fragment {
         super.onDestroy()
         if (bridge != null) {
             bridge?.onDestroy()
+            bridge?.onDetachedFromWindow()
         }
         for ((topic, ref) in subscriptions) {
             PortalsPlugin.unsubscribe(topic, ref)


### PR DESCRIPTION
This adds the call to destroy the webview to make the tear-down of a Portal View cleaner on memory.

The Bridge `onDetachedFromWindow()` handles it but it was not implemented since Fragments don't have an `onDetachedFromWindow()` method to override. Incorporated in the `onDestroy()` method.