### PR TITLE
chore: update dependency versions to capacitor 3.4.0 and liveupdates 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.6.3]() (2022-09-09)
+
+* chore: update dependency versions to capacitor 3.7.0 and liveupdates 0.1.1
+
+
+
+
+
+
 # [0.6.2]() (2022-09-09)
 
 * fix: added webview destroy call to PortalFragment

--- a/IonicPortals/build.gradle.kts
+++ b/IonicPortals/build.gradle.kts
@@ -38,8 +38,8 @@ android {
 dependencies {
     implementation(kotlin("reflect"))
 
-    api("com.capacitorjs:core:3.5.1")
-    compileOnly("io.ionic:liveupdates:0.0.7")
+    api("com.capacitorjs:core:3.7.0")
+    compileOnly("io.ionic:liveupdates:0.1.1")
 
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.0")
     implementation( "androidx.core:core-ktx:1.6.0")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ionic-portals-android",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Ionic Portals",
   "homepage": "https://ionic.io/portals",
   "author": "Ionic Team <hi@ionic.io> (https://ionic.io)",


### PR DESCRIPTION
Compatibility with secure live updates