### PR TITLE
feat: plugin instance support

### DIFF
--- a/IonicPortals/build.gradle.kts
+++ b/IonicPortals/build.gradle.kts
@@ -42,7 +42,7 @@ android {
 dependencies {
     implementation(kotlin("reflect"))
 
-    api("com.capacitorjs:core:4.5.0")
+    api("com.capacitorjs:core:4.6.1")
     compileOnly("io.ionic:liveupdates:0.2.0")
 
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.3")

--- a/IonicPortals/src/main/kotlin/io/ionic/portals/Portal.kt
+++ b/IonicPortals/src/main/kotlin/io/ionic/portals/Portal.kt
@@ -22,6 +22,13 @@ class Portal(
     internal val plugins = ArrayList<Class<out Plugin?>>()
 
     /**
+     * Get the list of Capacitor [Plugin] instances added to the Portal.
+     *
+     * @return The list of plugins registered with the Portal.
+     */
+    internal val pluginInstances = ArrayList<Plugin>()
+
+    /**
      * Initialize the Portal and add the PortalsPlugin by default.
      */
     init {
@@ -77,12 +84,30 @@ class Portal(
     /**
      * Add multiple Capacitor [Plugin] to be loaded with this Portal.
      *
-     * @param plugin A Plugin to be used with the Portal.
+     * @param plugins A list of Plugins to be used with the Portal.
      */
     fun addPlugins(plugins: List<Class<out Plugin?>>) {
         plugins.forEach {
             this.addPlugin(it)
         }
+    }
+
+    /**
+     * Add a Capacitor [Plugin] instance to be loaded with this Portal.
+     *
+     * @param plugin A Plugin instance to be used with the Portal.
+     */
+    fun addPluginInstance(plugin: Plugin) {
+        pluginInstances.add(plugin)
+    }
+
+    /**
+     * Add multiple Capacitor [Plugin] instances to be loaded with this Portal.
+     *
+     * @param plugins A list of Plugin instances to be used with the Portal.
+     */
+    fun addPluginInstances(plugins: List<Plugin>) {
+        pluginInstances.addAll(plugins)
     }
 
     /**
@@ -108,6 +133,7 @@ class Portal(
 class PortalBuilder(val name: String) {
     private var _startDir: String? = null
     private var plugins = mutableListOf<Class<out Plugin?>>()
+    private var pluginInstances = mutableListOf<Plugin>()
     private var initialContext: Any? = null
     private var portalFragmentType: Class<out PortalFragment?> = PortalFragment::class.java
     private var onCreate: (portal: Portal) -> Unit = {}
@@ -124,6 +150,11 @@ class PortalBuilder(val name: String) {
 
     fun addPlugin(plugin: Class<out Plugin?>): PortalBuilder {
         plugins.add(plugin)
+        return this
+    }
+
+    fun addPluginInstance(plugin: Plugin): PortalBuilder {
+        pluginInstances.add(plugin)
         return this
     }
 
@@ -158,6 +189,7 @@ class PortalBuilder(val name: String) {
         val portal = Portal(name)
         portal.startDir = this._startDir ?: this.name
         portal.addPlugins(plugins)
+        portal.addPluginInstances(pluginInstances)
         portal.initialContext = this.initialContext
         portal.portalFragmentType = this.portalFragmentType
         portal.liveUpdateConfig = this.liveUpdateConfig

--- a/IonicPortals/src/main/kotlin/io/ionic/portals/PortalFragment.kt
+++ b/IonicPortals/src/main/kotlin/io/ionic/portals/PortalFragment.kt
@@ -26,6 +26,7 @@ open class PortalFragment : Fragment {
     private var bridge: Bridge? = null
     private var keepRunning = true
     private val initialPlugins: MutableList<Class<out Plugin?>> = ArrayList()
+    private val initialPluginInstances: MutableList<Plugin> = ArrayList()
     private var config: CapConfig? = null
     private val webViewListeners: MutableList<WebViewListener> = ArrayList()
     private var subscriptions = mutableMapOf<String, Int>()
@@ -87,6 +88,10 @@ open class PortalFragment : Fragment {
 
     fun addPlugin(plugin: Class<out Plugin?>?) {
         initialPlugins.add(plugin!!)
+    }
+
+    fun addPluginInstance(plugin: Plugin) {
+        initialPluginInstances.add(plugin)
     }
 
     fun setConfig(config: CapConfig?) {
@@ -152,6 +157,7 @@ open class PortalFragment : Fragment {
                 if (portal != null) {
                     val startDir: String = portal?.startDir!!
                     initialPlugins.addAll(portal?.plugins!!)
+                    initialPluginInstances.addAll(portal?.pluginInstances!!)
 
                     if(config == null) {
                         config = CapConfig.Builder(requireContext()).setInitialFocus(false).create()
@@ -160,6 +166,7 @@ open class PortalFragment : Fragment {
                     var bridgeBuilder = Bridge.Builder(this)
                         .setInstanceState(savedInstanceState)
                         .setPlugins(initialPlugins)
+                        .addPluginInstances(initialPluginInstances)
                         .setConfig(config)
                         .addWebViewListeners(webViewListeners);
 


### PR DESCRIPTION
adds support for Capacitor plugin instances to Portals to register pre-created instances of plugins to the Capacitor bridge.