### PR TITLE
feat: callback when bridge is created

### DIFF
--- a/IonicPortals/src/main/kotlin/io/ionic/portals/PortalFragment.kt
+++ b/IonicPortals/src/main/kotlin/io/ionic/portals/PortalFragment.kt
@@ -22,6 +22,7 @@ open class PortalFragment : Fragment {
     val PORTAL_NAME = "PORTALNAME"
     var portal: Portal? = null
     var liveUpdateFiles: File? = null
+    var onBridgeAvailable: ((bridge: Bridge) -> Unit)? = null
 
     private var bridge: Bridge? = null
     private var keepRunning = true
@@ -36,6 +37,11 @@ open class PortalFragment : Fragment {
 
     constructor(portal: Portal?) {
         this.portal = portal
+    }
+
+    constructor(portal: Portal?, onBridgeAvailable: (bridge: Bridge) -> Unit) {
+        this.portal = portal
+        this.onBridgeAvailable = onBridgeAvailable
     }
 
     override fun onCreateView(
@@ -184,6 +190,8 @@ open class PortalFragment : Fragment {
                     bridge = bridgeBuilder.create()
                     setupInitialContextListener()
                     keepRunning = bridge?.shouldKeepRunning()!!
+
+                    onBridgeAvailable?.let { onBridgeAvailable -> bridge?.let { bridge -> onBridgeAvailable(bridge)} }
                 }
             }
         } else if (PortalManager.isRegisteredError()) {


### PR DESCRIPTION
Creates a callback similar to iOS https://github.com/ionic-team/ionic-portals-ios/blob/0cc7e1a025958f4731fde861fd1a1cf24211c2ed/Sources/IonicPortals/PortalView.swift#L14

passes the bridge to the callback when the private `load()` function is finished and the bridge should be non null. Requested by Paylocity. It was possible to get the bridge before but no assurance it was not null until after `load()` had been called.

Will add usage examples to the docs. 

## Kotlin use:

```Kotlin
val portalFragment = PortalFragment(checkoutPortal, (bridge) -> {
    val portalWebView = bridge.getWebView();
});
```

## Java use:

Direct use:

```Java
portalFragment = new PortalFragment(checkoutPortal, (bridge) -> {
    WebView portalWebView = bridge.getWebView();
    return null;
});
```

Subclass:

```Java
public class ProfileFragment extends PortalFragment {

    public static ProfileFragment newInstance() {
        return new ProfileFragment(PortalManager.getPortal("profile"), (bridge) -> {
            WebView myWebView = bridge.getWebView();
            return null;
        });
    }

    public ProfileFragment() {
        super();
    }

    public ProfileFragment(Portal portal) {
        super(portal);
    }

    public ProfileFragment(@Nullable Portal portal, @NonNull Function1<? super Bridge, Unit> onBridgeAvailable) {
        super(portal, onBridgeAvailable);
    }

    @Override
    public void onViewCreated(@NotNull View view, Bundle savedInstanceState) {
        super.onViewCreated(view, savedInstanceState);
        setHasOptionsMenu(false);
    }
}
```