### PR TITLE
feat!: BREAKING Overhauls to the pub/sub system

### DIFF
--- a/IonicPortals/src/main/kotlin/io/ionic/portals/PortalFragment.kt
+++ b/IonicPortals/src/main/kotlin/io/ionic/portals/PortalFragment.kt
@@ -71,7 +71,7 @@ open class PortalFragment : Fragment {
             bridge?.onDetachedFromWindow()
         }
         for ((topic, ref) in subscriptions) {
-            PortalsPlugin.unsubscribe(topic, ref)
+            PortalsPubSub.shared.unsubscribe(topic, ref)
         }
     }
 
@@ -332,7 +332,8 @@ open class PortalFragment : Fragment {
      * different name. The registered methods should accept a single String representing the payload
      * of a message sent through the Portal.
      */
-    fun linkMessageReceivers(messageReceiverParent: Any) {
+    @JvmOverloads
+    fun linkMessageReceivers(messageReceiverParent: Any, pubSub: PortalsPubSub = PortalsPubSub.shared) {
         val members = messageReceiverParent.javaClass.kotlin.members.filter { it.annotations.any { annotation -> annotation is PortalMethod } }
 
         for (member in members) {
@@ -349,13 +350,13 @@ open class PortalFragment : Fragment {
 
             when (member.parameters.size) {
                 1 -> {
-                    val ref = PortalsPlugin.subscribe(methodName) { result ->
+                    val ref = pubSub.subscribe(methodName) { result ->
                         member.call(messageReceiverParent)
                     }
                     subscriptions[methodName] = ref
                 }
                 2 -> {
-                    val ref = PortalsPlugin.subscribe(methodName) { result ->
+                    val ref = pubSub.subscribe(methodName) { result ->
                         member.call(messageReceiverParent, result.data)
                     }
                     subscriptions[methodName] = ref

--- a/IonicPortals/src/main/kotlin/io/ionic/portals/PortalFragment.kt
+++ b/IonicPortals/src/main/kotlin/io/ionic/portals/PortalFragment.kt
@@ -32,6 +32,7 @@ open class PortalFragment : Fragment {
     private var config: CapConfig? = null
     private val webViewListeners: MutableList<WebViewListener> = ArrayList()
     private var subscriptions = mutableMapOf<String, Int>()
+    private var pubSub = PortalsPubSub.shared
     private var initialContext: Any? = null
 
     constructor()
@@ -71,7 +72,7 @@ open class PortalFragment : Fragment {
             bridge?.onDetachedFromWindow()
         }
         for ((topic, ref) in subscriptions) {
-            PortalsPubSub.shared.unsubscribe(topic, ref)
+            pubSub.unsubscribe(topic, ref)
         }
     }
 
@@ -334,6 +335,7 @@ open class PortalFragment : Fragment {
      */
     @JvmOverloads
     fun linkMessageReceivers(messageReceiverParent: Any, pubSub: PortalsPubSub = PortalsPubSub.shared) {
+        this.pubSub = pubSub
         val members = messageReceiverParent.javaClass.kotlin.members.filter { it.annotations.any { annotation -> annotation is PortalMethod } }
 
         for (member in members) {

--- a/IonicPortals/src/main/kotlin/io/ionic/portals/PortalFragment.kt
+++ b/IonicPortals/src/main/kotlin/io/ionic/portals/PortalFragment.kt
@@ -443,7 +443,11 @@ open class PortalFragment : Fragment {
      * different name. The registered methods should accept a single String representing the payload
      * of a message sent through the Portal.
      *
+     * An instance of [PortalsPubSub] can be provided to override the default behavior of publishing
+     * events through [PortalsPubSub.shared].
+     *
      * @param messageReceiverParent a class that contains [PortalMethod] annotated functions
+     * @param pubSub an instance of [PortalsPubSub]. Defaults to [PortalsPubSub.shared].
      */
     @JvmOverloads
     fun linkMessageReceivers(messageReceiverParent: Any, pubSub: PortalsPubSub = PortalsPubSub.shared) {

--- a/IonicPortals/src/main/kotlin/io/ionic/portals/PortalsPlugin.kt
+++ b/IonicPortals/src/main/kotlin/io/ionic/portals/PortalsPlugin.kt
@@ -70,7 +70,7 @@ class PortalsPubSub {
  * added like other plugins if the default behavior is desired.
  *
  * If events should be scoped to a specific Portal or group of Portals, this should be initialized
- * with an instance of [PortalsPubSub] and added to [Portal.pluginInstances] via
+ * with an instance of [PortalsPubSub] and added to a Portal via [Portal.addPluginInstance] or
  * [PortalBuilder.addPluginInstance].
  */
 @CapacitorPlugin(name = "Portals")

--- a/IonicPortals/src/main/kotlin/io/ionic/portals/PortalsPlugin.kt
+++ b/IonicPortals/src/main/kotlin/io/ionic/portals/PortalsPlugin.kt
@@ -96,7 +96,6 @@ data class SubscriptionResult(val topic: String, val data: Any?, val subscriptio
         val jsObject = JSObject()
         jsObject.put("topic", this.topic)
         jsObject.put("data", this.data)
-        jsObject.put("subscriptionRef", this.subscriptionRef)
         return jsObject
     }
 }

--- a/IonicPortals/src/main/kotlin/io/ionic/portals/PortalsPlugin.kt
+++ b/IonicPortals/src/main/kotlin/io/ionic/portals/PortalsPlugin.kt
@@ -77,9 +77,7 @@ class PortalsPlugin(private val pubSub: PortalsPubSub = PortalsPubSub.shared) : 
 
     override fun handleOnDestroy() {
         super.handleOnDestroy()
-        Log.i("PUBSUB RECEIVED", "In handleOnDestroy")
         for ((key, ref) in subscriptionRefs) {
-            Log.i("PUBSUB RECEIVED", "Unsubscribing from $key for subRef $ref");
             pubSub.unsubscribe(key, ref)
         }
     }


### PR DESCRIPTION
* Breaks out a separate PortalsPubSub class from PortalsPlugin to separate the event bus logic from the implementation of the Plugin

* Makes PortalsPlugin useable as an instance plugin to scope events to a specific instance of PortalsPubSub

* Adds the ability to scope the pubSub instance in `linkMessageReceivers` on PortalFragment.