### PR TITLE
chore: change release and publishing flow

### DIFF
--- a/.github/workflows/docs-production.yml
+++ b/.github/workflows/docs-production.yml
@@ -1,9 +1,9 @@
 name: Deploy docs to production
 
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [published]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -1,6 +1,10 @@
 name: Publish Native Android Library
 
-on: workflow_dispatch
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+
 jobs:
   publish-android:
     runs-on: ubuntu-latest
@@ -18,6 +22,13 @@ jobs:
         run: chmod +x ./gradlew
       - name: Grant execute permission for publishing script
         run: chmod +x ./scripts/publish-android.sh
+      - name: Assemble release and add artifact to GH Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ github.event_name == 'release' }}
+        run: |
+          ./gradlew assembleRelease
+          gh release upload ${{ github.event.release.tag_name }} ./IonicPortals/build/outputs/aar/*.aar
       - name: Run publish script
         working-directory: ./scripts
         env:

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -2,7 +2,7 @@ name: Publish Native Android Library
 
 on:
   release:
-    types: [created]
+    types: [published]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This PR changes how Portals and docs are released for Android. It uses the Github Release process to publish to Maven Central and publish the latest docs to production. It also fixes the issue where unreleased working changes were published to production in the docs before being officially released.