### PR TITLE
fix: fix transaction exception crashing the app if the view no longer exists

### DIFF
--- a/IonicPortals/src/main/kotlin/io/ionic/portals/PortalView.kt
+++ b/IonicPortals/src/main/kotlin/io/ionic/portals/PortalView.kt
@@ -15,6 +15,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
 import com.getcapacitor.Bridge
+import com.getcapacitor.Logger
 import java.util.ArrayList
 
 /**
@@ -193,10 +194,15 @@ class PortalView : FrameLayout {
             }
             val handler = Handler()
             val runnable = Runnable {
-                fmTransaction
-                    .setReorderingAllowed(true)
-                    .add(id, portalFragment!!, "")
-                    .commitNowAllowingStateLoss()
+                val thisView = findViewById<PortalView>(id)
+                if(thisView != null) {
+                    fmTransaction
+                        .setReorderingAllowed(true)
+                        .add(id, portalFragment!!, "")
+                        .commitNowAllowingStateLoss()
+                } else {
+                    Logger.warn("PortalView", "Unable to find active PortalView with id: $id. Skipping Portal inflation.")
+                }
             }
 
             handler.post(runnable)


### PR DESCRIPTION
In theory this was occurring on views that were no longer used