### PR TITLE
fix: prevent full crash when returning from a force-quit state

### DIFF
--- a/IonicPortals/src/main/kotlin/io/ionic/portals/PortalFragment.kt
+++ b/IonicPortals/src/main/kotlin/io/ionic/portals/PortalFragment.kt
@@ -300,7 +300,13 @@ open class PortalFragment : Fragment {
 
                 val existingPortalName = savedInstanceState?.getString(PORTAL_NAME, null)
                 if (existingPortalName != null && portal == null) {
-                    portal = PortalManager.getPortal(existingPortalName)
+                    try {
+                        portal = PortalManager.getPortal(existingPortalName)
+                    } catch (e: Exception) {
+                        Logger.warn("Attempted to reload PortalFragment from App restore but portal not found.")
+                        Logger.warn("No portal named $existingPortalName found in PortalManager to use.")
+                        Logger.warn("Portal reload is unsuccessful. This is likely okay and safe to ignore if your app is returning from a force quit state.")
+                    }
                 }
 
                 if (portal != null) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ionic-portals-android",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Ionic Portals",
   "homepage": "https://ionic.io/portals",
   "author": "Ionic Team <hi@ionic.io> (https://ionic.io)",


### PR DESCRIPTION
Apps still crashed if returning from a force-quit state by Android (such as permission change in Settings) and last fragment was trying to reload in the background while new refreshed content was loading. Removing this exception resolves the issue. Replaced with a warning log for troubleshooting purposes if execution reaches this point unexpectedly.