### PR TITLE
feat: Capacitor v6.* Update

### DIFF
--- a/IonicPortals/build.gradle.kts
+++ b/IonicPortals/build.gradle.kts
@@ -44,8 +44,8 @@ android {
 dependencies {
     implementation(kotlin("reflect"))
 
-    api("com.capacitorjs:core:[6.0.0,6.1.0)")
-    compileOnly("io.ionic:liveupdates:0.5.1")
+    api("com.capacitorjs:core:[6.0.0,7.0.0)")
+    compileOnly("io.ionic:liveupdates:0.5.5")
 
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
     implementation("androidx.core:core-ktx:1.12.0")


### PR DESCRIPTION
This servers as a final update to Portals 0.10 to support the last versions of Capacitor 6, up-to but not including Capacitor 7. Next version of Portals will support Capacitor 7